### PR TITLE
Corrigir uploads não serem adicionados ao `$request->getData()` e `$request->getParsedBody()`

### DIFF
--- a/src/Bridge.php
+++ b/src/Bridge.php
@@ -9,8 +9,8 @@ use Cake\Http\MiddlewareQueue;
 use Cake\Http\Runner;
 use Cake\Http\Server;
 use Cake\Http\ServerRequest;
-use CakeDC\Roadrunner\Http\ServerRequestFactory;
 use CakeDC\Roadrunner\Exception\CakeRoadrunnerException;
+use CakeDC\Roadrunner\Http\ServerRequestFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
@@ -112,7 +112,13 @@ class Bridge
         return $response;
     }
 
-    private static function buildHostHeaderFromUri(UriInterface $uri): string
+    /**
+     * Generates a host header, based upon the contents from the URI.
+     *
+     * @param \Psr\Http\Message\UriInterface $uri The request's URI
+     * @return string The generated Host header.
+     */
+    protected static function buildHostHeaderFromUri(UriInterface $uri): string
     {
         $uriPort = $uri->getPort();
         if ($uriPort === null) {

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -8,7 +8,7 @@ use Cake\Http\Response;
 class ErrorHandler
 {
     public const TITLE = 'CakeDC Roadrunner Error';
-    
+
     /**
      * Return an error response.
      *

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -12,6 +12,9 @@ class Session extends BaseSession
 {
     protected array $_requestCookies = [];
 
+    /**
+     * @inheritDoc
+     */
     public function __construct(array $config = [])
     {
         parent::__construct($config);
@@ -19,6 +22,12 @@ class Session extends BaseSession
         $this->_isCLI = false;
     }
 
+    /**
+     * Set the cookies used for this session.
+     *
+     * @param array $requestCookies The request's cookies
+     * @return void
+     */
     public function setRequestCookies(array $requestCookies): void
     {
         $this->_requestCookies = $requestCookies;


### PR DESCRIPTION
No código original do CakePHP tinham alguns trechos que pegavam os arquivos enviados e adicionavam eles ao corpo da request, que não existiam na implementação usada para suporte ao Roadrunner