### PR TITLE
Não realizar parse de requisições `application/x-www-form-urlencoded` recebidas pelo Roadrunner

### DIFF
--- a/src/Http/ServerRequestFactory.php
+++ b/src/Http/ServerRequestFactory.php
@@ -43,6 +43,7 @@ class ServerRequestFactory extends BaseServerRequestFactory
             'uri' => $uri,
             'cookies' => $cookies ?: $_COOKIE,
             'query' => $query ?: $_GET,
+            'post' => $parsedBody ?: $_POST,
             /** @phpstan-ignore-next-line */
             'webroot' => $uri->webroot,
             /** @phpstan-ignore-next-line */
@@ -52,7 +53,6 @@ class ServerRequestFactory extends BaseServerRequestFactory
 
         $session->setRequestCookies($request->getCookieParams());
 
-        $request = static::marshalBodyAndRequestMethod($parsedBody ?? $_POST, $request);
         $request = static::marshalFiles($files ?? $_FILES, $request);
 
         return $request;

--- a/tests/TestCase/BridgeTest.php
+++ b/tests/TestCase/BridgeTest.php
@@ -125,4 +125,25 @@ class BridgeTest extends TestCase
         $this->assertInstanceOf(UploadedFile::class, $uploadedFile);
         $this->assertEquals('test.txt', $uploadedFile->getClientFilename());
     }
+
+    public function test_convert_request_should_not_attempt_to_parse_request_body_when_is_put_with_urlencoded_parameters(): void
+    {
+        $urlEncodedParameters = [
+            'test' => 123,
+        ];
+
+        // Roadrunner sends the request body encoded with JSON, even when it was originally parsed
+        // from a `application/x-www-form-urlencoded` request
+        $stream = (new StreamFactory())->createStream(json_encode($urlEncodedParameters));
+        $request = (new ServerRequest())
+            ->withMethod('PUT')
+            ->withHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8')
+            ->withBody($stream)
+            ->withParsedBody($urlEncodedParameters);
+
+        $convertedRequest = Bridge::convertRequest($request);
+        $parsedBody = $convertedRequest->getParsedBody();
+
+        $this->assertEquals($urlEncodedParameters, $parsedBody);
+    }
 }


### PR DESCRIPTION
Quando recebemos requisições do Roadrunner com o tipo `application/x-www-form-urlencoded`, elas já vem com o campo `$parsedBody` preenchidos, e como corpo da requisição vem um JSON que contem esses campos. A função `marshalBodyAndRequestMethod` do Cake tentava realizar o parse desse corpo da requisição novamente, e sobrescrevia o `$parsedBody` vindo do Roadrunner com uma array vazia, pois falhava em parsear o corpo vindo em JSON.

Para corrigir, apenas parei de parsear esse corpo, mantendo o `$parsedBody` enviado pelo Roadrunner

- [ ] Atualizar a dependencia no monolito depois de mergear (tem que rodar `docker exec web1 composer require "cakedc/cakephp-roadrunner:dev-2.next-cake4"` na branch do `enhancement-use-roadrunner`)