### PR TITLE
fix: copiar `Uri` da request original

### DIFF
--- a/src/Bridge.php
+++ b/src/Bridge.php
@@ -165,6 +165,7 @@ class Bridge
         $cakeRequest->trustProxy = true;
 
         $cakeRequest = static::copyHeadersFromRoadrunnerRequest($cakeRequest, $request);
+        $cakeRequest = $cakeRequest->withUri($request->getUri());
 
         $request->getBody()->rewind();
 

--- a/tests/TestCase/BridgeTest.php
+++ b/tests/TestCase/BridgeTest.php
@@ -180,4 +180,22 @@ class BridgeTest extends TestCase
 
         $this->assertEquals($expectedEnvironmentValue, $convertedRequest->getEnv('HTTP_X_REAL_IP'));
     }
+
+    public function test_convert_request_should_keep_uri_parameters(): void
+    {
+        $serverParams = [
+            'REQUEST_URI' => 'http://localhost/test?parameter=1',
+        ];
+
+        $requestUri = new Uri('http://localhost/test?parameter=1');
+        $request = (new LaminasServerRequest($serverParams))
+            ->withUri($requestUri);
+
+        $convertedRequest = Bridge::convertRequest($request);
+
+        $this->assertEquals('http', $convertedRequest->getUri()->getScheme());
+        $this->assertEquals('localhost', $convertedRequest->getUri()->getHost());
+        $this->assertEquals('parameter=1', $convertedRequest->getUri()->getQuery());
+        $this->assertEquals('/test?parameter=1', $convertedRequest->getRequestTarget());
+    }
 }


### PR DESCRIPTION
A URI que vinha na request convertida não continha o campo `query` correto, o que fazia com que o método `$request->getRequestTarget()` viesse sem os query parameters, para resolver copiamos a URI da request original vinda do Roadrunner