### PR TITLE
fix: corrigir erro ao usar `RedirectException` no controller

### DIFF
--- a/src/Bridge.php
+++ b/src/Bridge.php
@@ -6,10 +6,10 @@ namespace CakeDC\Roadrunner;
 use Cake\Core\HttpApplicationInterface;
 use Cake\Core\PluginApplicationInterface;
 use Cake\Http\MiddlewareQueue;
+use Cake\Http\Response as CakeResponse;
 use Cake\Http\Runner;
 use Cake\Http\Server;
 use Cake\Http\ServerRequest as CakeServerRequest;
-use Cake\Http\Response as CakeResponse;
 use CakeDC\Roadrunner\Exception\CakeRoadrunnerException;
 use CakeDC\Roadrunner\Http\ServerRequestFactory;
 use Laminas\Diactoros\ServerRequest as LaminasServerRequest;
@@ -108,7 +108,7 @@ class Bridge
     /**
      * Returns a list of cookie header values, suitable for usage with the `Set-Cookie` header.
      *
-     * @param ResponseInterface $response The response to look for cookies
+     * @param \Psr\Http\Message\ResponseInterface $response The response to look for cookies
      * @return array
      */
     private function tryToGetCookiesFromResponse(ResponseInterface $response): array

--- a/tests/TestCase/BridgeTest.php
+++ b/tests/TestCase/BridgeTest.php
@@ -3,7 +3,6 @@
 namespace CakeDC\Roadrunner\Test\TestCase;
 
 use Cake\Core\Configure;
-use Cake\Http\ServerRequest as CakeServerRequest;
 use Cake\TestSuite\TestCase;
 use CakeDC\Roadrunner\Bridge;
 use CakeDC\Roadrunner\Exception\CakeRoadrunnerException;
@@ -24,6 +23,7 @@ class BridgeTest extends TestCase
         Configure::write('Error', []);
         Configure::write('debug', true);
         Configure::write('App.namespace', 'App\\');
+        Configure::write('App.fullBaseUrl', 'http://localhost:8080');
         $this->rootDir = dirname(__DIR__ . '../') . '/test_app';
     }
 
@@ -75,6 +75,20 @@ class BridgeTest extends TestCase
         $response = (new Bridge($this->rootDir))->handle($request);
         $this->assertEquals(204, $response->getStatusCode());
         $this->assertEquals('', (string) $response->getBody());
+    }
+
+    public function test_handle_with_redirect_exception(): void
+    {
+        $request = LaminasServerRequestFactory::fromGlobals(
+            ServerRequestHelper::defaultServerParams([
+                'REQUEST_URI' => 'http://localhost:8080/test_redirect_exception.json',
+                'REQUEST_METHOD' => 'GET',
+            ])
+        );
+
+        $response = (new Bridge($this->rootDir))->handle($request);
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals('http://localhost:8080/redirected_location.json', $response->getHeaderLine('Location'));
     }
 
     public function test_construct_throws_exception_when_root_dir_not_found(): void

--- a/tests/test_app/config/routes.php
+++ b/tests/test_app/config/routes.php
@@ -31,6 +31,7 @@ return static function (RouteBuilder $routes) {
         $builder->connect('/', ['controller' => 'Tests', 'action' => 'index', '_ext' => 'json']);
         $builder->connect('/write', ['controller' => 'Tests', 'action' => 'write', '_ext' => 'json']);
         $builder->connect('/delete', ['controller' => 'Tests', 'action' => 'delete', '_ext' => 'json']);
+        $builder->connect('/test_redirect_exception', ['controller' => 'Tests', 'action' => 'test_redirect_exception', '_ext' => 'json']);
         $builder->fallbacks();
     });
 };

--- a/tests/test_app/src/Controller/TestsController.php
+++ b/tests/test_app/src/Controller/TestsController.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 namespace App\Controller;
 
 
+use Cake\Http\Exception\RedirectException;
+use Cake\Routing\Router;
+
 class TestsController extends AppController
 {
     public function initialize() : void
@@ -31,5 +34,10 @@ class TestsController extends AppController
     {
         $this->request->allowMethod('DELETE');
         return $this->response->withStatus(204);
+    }
+
+    public function testRedirectException()
+    {
+        throw new RedirectException(Router::url('/redirected_location.json', full: true));
     }
 }


### PR DESCRIPTION
Corrige um erro que ocorria quando usávamos o `RedirectException` no controller, pois nesse caso a resposta que voltava da execução da request não era uma `Cake\Http\Response`, mas sim uma `Laminas\Diactoros\Response\RedirectResponse`